### PR TITLE
check geopoint key length

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -36,9 +36,9 @@ dynamic dartify(Object jsObject) {
   }
 
   if (util.hasProperty(jsObject, 'latitude') &&
-      util.hasProperty(jsObject, 'longitude')) {
+      util.hasProperty(jsObject, 'longitude') &&
+      js.objectKeys(jsObject).length == 2) {
     // This is likely a GeoPoint – return it as-is
-    // TODO(kevmoo): figure out if there is a more robust way to detect
     return jsObject as GeoPoint;
   }
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -1,5 +1,6 @@
 @TestOn('browser')
 import 'package:firebase/src/utils.dart';
+import 'package:firebase/src/interop/firestore_interop.dart';
 
 import 'package:test/test.dart';
 
@@ -19,7 +20,12 @@ void main() {
         'bool': true,
         'double': 1.1,
         'list': [1, 2, 3],
-        'map': {'a': true}
+        'map': {'a': true},
+        'not a geopoint': {
+          'latitude': 45.5122,
+          'longitude': -122.6587,
+          'foo': 'bar'
+        }
       };
 
       jsonObjects.forEach((key, value) {
@@ -33,6 +39,13 @@ void main() {
 
     test('custom object with toJson', () {
       expect(() => jsify(new _TestClassWithToJson()), throwsArgumentError);
+    });
+
+    test('geopoint', () {
+      var value = {'latitude': 45.5122, 'longitude': -122.6587};
+      var js = jsify(value);
+      var roundTrip = dartify(js);
+      expect(roundTrip, const TypeMatcher<GeoPoint>());
     });
   });
 }


### PR DESCRIPTION
There's a TODO in the code to find a better way to verify an object is a GeoPoint. AFAICT a geopoint will only ever have two keys: https://firebase.google.com/docs/reference/js/firebase.firestore.GeoPoint but this could be a wrong assumption.