### PR TITLE
feat: Timestamp support

### DIFF
--- a/lib/firestore.dart
+++ b/lib/firestore.dart
@@ -4,3 +4,4 @@
 library firebase_firestore;
 
 export 'src/firestore.dart' hide jsifyFieldValue;
+export 'src/timestamp.dart';

--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -32,8 +32,7 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
       return null;
     }
 
-    return _expando[jsObject] ??= Firestore._fromJsObject(jsObject
-      ..settings(firestore_interop.Settings(timestampsInSnapshots: true)));
+    return _expando[jsObject] ??= Firestore._fromJsObject(jsObject);
   }
 
   Firestore._fromJsObject(firestore_interop.FirestoreJsImpl jsObject)

--- a/lib/src/interop/firestore_interop.dart
+++ b/lib/src/interop/firestore_interop.dart
@@ -274,6 +274,12 @@ abstract class TimestampJsImpl {
   external String toString();
 }
 
+@JS()
+@anonymous
+abstract class DateJsImpl {
+  external int getTime();
+}
+
 /// The set of Cloud Firestore status codes.
 /// These status codes are also exposed by gRPC.
 ///

--- a/lib/src/interop/js_interop.dart
+++ b/lib/src/interop/js_interop.dart
@@ -1,6 +1,7 @@
 @JS()
 library firebase.js_interop;
 
+import 'package:firebase/src/interop/firestore_interop.dart';
 import 'package:js/js.dart';
 import 'package:js/js_util.dart' as util;
 
@@ -16,7 +17,7 @@ external Object toJSArray(List source);
 DateTime dartifyDate(Object jsObject) {
   if (util.hasProperty(jsObject, "toDateString")) {
     try {
-      var date = jsObject as dynamic;
+      var date = jsObject as DateJsImpl;
       return DateTime.fromMillisecondsSinceEpoch(date.getTime());
     } on NoSuchMethodError {
       // so it's not a JsDate!

--- a/lib/src/timestamp.dart
+++ b/lib/src/timestamp.dart
@@ -1,0 +1,201 @@
+/// A Timestamp represents a point in time independent of any time zone or
+/// calendar, represented as seconds and fractions of seconds at nanosecond
+/// resolution in UTC Epoch time.
+///
+/// Timestamps are encoded using the Proleptic Gregorian Calendar, which extends
+/// the Gregorian calendar backwards to year one. Timestamps assume all minutes
+/// are 60 seconds long, i.e. leap seconds are "smeared" so that no leap second
+/// table is needed for interpretation. Possible timestamp values range from
+/// 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+class Timestamp implements Comparable<Timestamp> {
+  final int seconds;
+  final int nanoseconds;
+
+  /// [seconds] is the number of [seconds] of UTC time since Unix epoch
+  /// 1970-01-01T00:00:00Z.
+  /// Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+  ///
+  /// [nanoseconds] is the non-negative fractions of a second at nanosecond
+  /// resolution. Negative second values with fractions must still have
+  /// non-negative nanoseconds values that count forward in time.
+  /// Must be from 0 to 999,999,999 inclusive.
+  Timestamp(int seconds, int nanoseconds)
+      : seconds = seconds ?? 0,
+        nanoseconds = nanoseconds ?? 0 {
+    if (seconds < -62135596800 || seconds > 253402300799) {
+      throw ArgumentError('invalid seconds part ${toDateTime(isUtc: true)}');
+    }
+    if (nanoseconds < 0 || nanoseconds > 999999999) {
+      throw ArgumentError(
+          'invalid nanoseconds part ${toDateTime(isUtc: true)}');
+    }
+  }
+
+  /// [parse] or returns null
+  static Timestamp tryParse(String text) {
+    if (text != null) {
+      // 2018-10-20T05:13:45.985343Z
+      var dateTime = DateTime.tryParse(text);
+
+      // remove after the seconds part
+      var subSecondsStart = text.lastIndexOf('.');
+      if (subSecondsStart == -1) {
+        if (dateTime == null) {
+          return null;
+        } else {
+          return Timestamp.fromDateTime(dateTime);
+        }
+      }
+
+      bool isDigit(String chr) => (chr.codeUnitAt(0) ^ 0x30) <= 9;
+
+      // Read the sun seconds part
+      var nanosString = StringBuffer();
+      var i = subSecondsStart + 1;
+      for (; i < text.length; i++) {
+        var char = text[i];
+        if (isDigit(char)) {
+          // Never write more than 9 chars
+          if (nanosString.length < 9) {
+            nanosString.write(char);
+          }
+        } else {
+          break;
+        }
+      }
+      // Never write less than 9 chars
+      while (nanosString.length < 9) {
+        nanosString.write('0');
+      }
+
+      // reparse the date if needed removing the sub seconds part
+      if (dateTime == null) {
+        var parseableDateTime =
+            '${text.substring(0, subSecondsStart)}${text.substring(i)}';
+        dateTime = DateTime.tryParse(parseableDateTime);
+        if (dateTime == null) {
+          // give up
+          return null;
+        }
+      }
+
+      var seconds = (dateTime.millisecondsSinceEpoch / 1000).floor();
+      var nanoseconds = int.tryParse(nanosString.toString());
+      return Timestamp(seconds, nanoseconds);
+    }
+    return null;
+  }
+
+  /// Creates a new [Timestamp] instance from the given date
+  factory Timestamp.fromDateTime(DateTime dateTime) {
+    final seconds = (dateTime.millisecondsSinceEpoch / 1000).floor();
+    final nanoseconds = (dateTime.microsecondsSinceEpoch % 1000000) * 1000;
+    return Timestamp(seconds, nanoseconds);
+  }
+
+  /// Constructs a new [Timestamp] instance
+  /// with the given [millisecondsSinceEpoch].
+  factory Timestamp.fromMillisecondsSinceEpoch(int millisecondsSinceEpoch) {
+    final seconds = (millisecondsSinceEpoch / 1000).floor();
+    final nanoseconds = (millisecondsSinceEpoch % 1000) * 1000000;
+    return Timestamp(seconds, nanoseconds);
+  }
+
+  /// Constructs a [Timestamp] instance with current date and time
+  factory Timestamp.now() => Timestamp.fromDateTime(DateTime.now());
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other is Timestamp) {
+      var typedOther = other;
+      return seconds == typedOther.seconds &&
+          nanoseconds == typedOther.nanoseconds;
+    }
+    return false;
+  }
+
+  @override
+  int get hashCode => (seconds ?? 0) + (nanoseconds ?? 0);
+
+  /// The number of milliseconds since
+  /// the "Unix epoch" 1970-01-01T00:00:00Z (UTC).
+  int get millisecondsSinceEpoch {
+    return seconds * 1000 + (nanoseconds ~/ 10000000);
+  }
+
+  // Not exported as we loose precision
+  int get _microsecondsSinceEpoch {
+    return (seconds * 1000000) + (nanoseconds ~/ 1000);
+  }
+
+  /// Convert a Timestamp to a [DateTime] object. This conversion
+  /// causes a loss of precision and support millisecond precision.
+  DateTime toDateTime({bool isUtc}) {
+    return DateTime.fromMicrosecondsSinceEpoch(_microsecondsSinceEpoch,
+        isUtc: isUtc == true);
+  }
+
+  static String _threeDigits(int n) {
+    if (n >= 100) return "$n";
+    if (n >= 10) return "0$n";
+    return "00$n";
+  }
+
+  static String _formatNanos(int nanoseconds) {
+    var ns = nanoseconds % 1000;
+    if (ns != 0) {
+      return '${_threeDigits(nanoseconds ~/ 1000000)}${_threeDigits((nanoseconds ~/ 1000) % 1000)}${_threeDigits(ns)}';
+    } else {
+      return _formatMicros(nanoseconds ~/ 1000);
+    }
+  }
+
+  static String _formatMicros(int microseconds) {
+    var us = microseconds % 1000;
+    return '${_formatMillis(microseconds ~/ 1000)}${us == 0 ? '' : _threeDigits(us)}';
+  }
+
+  static String _formatMillis(int milliseconds) => _threeDigits(milliseconds);
+
+  ///
+  /// Returns an ISO-8601 full-precision extended format representation.
+  /// The format is `yyyy-MM-ddTHH:mm:ss.mmmuuunnnZ`
+  /// nanoseconds and microseconds are omitted if null
+  String toIso8601String() {
+    // Use DateTime without the sub second part
+    var text = Timestamp(seconds, 0).toDateTime(isUtc: true).toIso8601String();
+    // Then add the nano part to it
+    var nanosStart = text.lastIndexOf('.') + 1;
+    return '${text.substring(0, nanosStart)}${_formatNanos(nanoseconds)}Z';
+  }
+
+  @override
+  String toString() => toIso8601String();
+
+  @override
+  int compareTo(Timestamp other) {
+    if (seconds != other.seconds) {
+      return seconds - other.seconds;
+    }
+    return nanoseconds - other.nanoseconds;
+  }
+
+  /// The function parses a subset of ISO 8601
+  /// which includes the subset accepted by RFC 3339.
+  ///
+  /// Compare to [DateTime.parse], it supports nanoseconds resolution
+  static Timestamp parse(String text) {
+    if (text == null) {
+      throw ArgumentError.notNull(text);
+    } else {
+      var timestamp = tryParse(text);
+      if (timestamp == null) {
+        throw FormatException('timestamp $text');
+      }
+      return timestamp;
+    }
+  }
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:html' show promiseToFuture;
 
+import 'package:firebase/src/timestamp.dart';
 import 'package:js/js.dart';
 import 'package:js/js_util.dart' as util;
 
@@ -46,8 +47,9 @@ dynamic dartify(Object jsObject) {
 
   if (util.hasProperty(proto, 'toDate') &&
       util.hasProperty(proto, 'toMillis')) {
-    return DateTime.fromMillisecondsSinceEpoch(
-        (jsObject as TimestampJsImpl).toMillis());
+    // This should be a Timestamp
+    var jsTimestamp = jsObject as TimestampJsImpl;
+    return Timestamp(jsTimestamp.seconds, jsTimestamp.nanoseconds);
   }
 
   if (util.hasProperty(proto, 'isEqual') &&
@@ -78,6 +80,10 @@ dynamic jsify(Object dartObject) {
 
   if (dartObject is DateTime) {
     return TimestampJsImpl.fromMillis(dartObject.millisecondsSinceEpoch);
+  }
+
+  if (dartObject is Timestamp) {
+    return TimestampJsImpl(dartObject.seconds, dartObject.nanoseconds);
   }
 
   if (dartObject is Iterable) {

--- a/test/firestore_with_timestamp_test.dart
+++ b/test/firestore_with_timestamp_test.dart
@@ -1,0 +1,1052 @@
+@TestOn('browser')
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:firebase/firebase.dart' as fb;
+import 'package:firebase/firestore.dart' as fs;
+import 'package:firebase/src/assets/assets.dart';
+import 'package:test/test.dart';
+import 'test_util.dart' show throwsToString, validDatePathComponent;
+
+//  TODO add MetadataSnapshot test
+//  TODO add enable/disable Network test
+
+// Delete entire collection
+// <https://firebase.google.com/docs/firestore/manage-data/delete-data#collections>
+Future _deleteCollection(fs.Firestore db, fs.CollectionReference collectionRef,
+    {int batchSize}) async {
+  batchSize ??= 4;
+  var query = collectionRef.orderBy('__name__').limit(batchSize);
+
+  int snapshotSize;
+  do {
+    var snapshot = await query.get();
+    snapshotSize = snapshot.size;
+
+    // When there are no documents left, we are done
+    if (snapshotSize == 0) {
+      break;
+    }
+
+    // Delete documents in a batch
+    var batch = db.batch();
+    for (var doc in snapshot.docs) {
+      batch.delete(doc.ref);
+    }
+
+    await batch.commit();
+  } while (snapshotSize > batchSize);
+}
+
+void main() {
+  final testPath = 'pkg_firebase_test_${validDatePathComponent()}';
+
+  fb.App app;
+  fs.Firestore firestore;
+
+  setUpAll(() async {
+    await config();
+  });
+
+  setUp(() async {
+    app = fb.initializeApp(
+        apiKey: apiKey,
+        authDomain: authDomain,
+        databaseURL: databaseUrl,
+        projectId: projectId,
+        storageBucket: storageBucket);
+
+    firestore = fb.firestore();
+    // Use timestamps
+    firestore.settings(fs.Settings(timestampsInSnapshots: true));
+  });
+
+  tearDown(() async {
+    if (app != null) {
+      await app.delete();
+      app = null;
+    }
+  });
+
+  group("instance", () {
+    test("App exists", () {
+      expect(firestore, isNotNull);
+      expect(firestore.app, isNotNull);
+      expect(firestore.app.name, fb.app().name);
+    });
+  });
+
+  group('equality', () {
+    test("GeoPoint", () {
+      var a = fs.GeoPoint(1, 2);
+      var b = fs.GeoPoint(1, 2);
+      expect(a.isEqual(b), isTrue);
+      expect(a.isEqual(a), isTrue);
+      expect(b.isEqual(a), isTrue);
+    });
+
+    test("FieldValue", () {
+      var a = fs.FieldValue.delete();
+      var b = fs.FieldValue.delete();
+      expect(a, b);
+      expect(a, a);
+      expect(b, a);
+
+      a = fs.FieldValue.serverTimestamp();
+      b = fs.FieldValue.serverTimestamp();
+      expect(a, b);
+      expect(a, a);
+      expect(b, a);
+    });
+
+    test("FieldPath", () {
+      var a = fs.FieldPath('bob');
+      var b = fs.FieldPath('bob');
+      expect(a.isEqual(b), isTrue);
+      expect(a.isEqual(a), isTrue);
+      expect(b.isEqual(a), isTrue);
+    });
+
+    test("Blob", () {
+      var a = fs.Blob.fromBase64String('AQIDBA==');
+      var b = fs.Blob.fromBase64String('AQIDBA==');
+      expect(a.isEqual(b), isTrue);
+      expect(a.isEqual(a), isTrue);
+      expect(b.isEqual(a), isTrue);
+
+      var c = fs.Blob.fromUint8Array(Uint8List.fromList([1, 2, 3, 4]));
+      expect(a.isEqual(c), isTrue);
+      expect(c.isEqual(a), isTrue);
+    });
+  });
+
+  group("Collections and documents", () {
+    fs.CollectionReference ref;
+
+    setUp(() {
+      ref = firestore.collection(testPath);
+    });
+
+    tearDown(() async {
+      if (ref != null) {
+        await _deleteCollection(firestore, ref);
+        ref = null;
+      }
+    });
+
+    test("collection exists", () {
+      expect(ref, isNotNull);
+      expect(ref.id, ref.path);
+      expect(ref.path, ref.path);
+    });
+
+    test("create document with auto generated ID", () {
+      var docRef = ref.doc();
+
+      expect(docRef, isNotNull);
+      expect(docRef.id, isNotEmpty);
+    });
+
+    test("create document", () {
+      var docRef = ref.doc("message1");
+
+      expect(docRef, isNotNull);
+      expect(docRef.id, "message1");
+      expect(docRef.path, "${ref.path}/message1");
+      expect(docRef.parent.id, ref.id);
+    });
+
+    test("get document in collection", () {
+      var docRef = ref.doc("message2");
+      var docRefSecond = firestore.doc("messages/message2");
+      expect(docRefSecond, isNotNull);
+      expect(docRefSecond.id, docRef.id);
+    });
+
+    test("get document in collection of document", () {
+      var docRef = ref.doc("message3").collection("words").doc("word1");
+      expect(docRef, isNotNull);
+      expect(docRef.id, "word1");
+    });
+
+    test("collection path", () {
+      var childRef = firestore.collection("${ref.path}/message4/words");
+      expect(childRef, isNotNull);
+      expect(childRef.id, "words");
+      expect(childRef.parent.id, "message4");
+    });
+  });
+
+  group("DocumentReference", () {
+    fs.CollectionReference ref;
+
+    setUp(() {
+      ref = firestore.collection(testPath);
+    });
+
+    tearDown(() async {
+      if (ref != null) {
+        await _deleteCollection(firestore, ref);
+        ref = null;
+      }
+    });
+
+    test("ref is equal", () async {
+      var a = firestore.collection('a');
+      var b = firestore.collection('a');
+
+      expect(a.isEqual(b), isTrue);
+      expect(a.isEqual(ref), isFalse);
+
+      await _deleteCollection(firestore, a);
+      await _deleteCollection(firestore, b);
+    });
+
+    test("delete collection", () async {
+      var nycRef = ref.doc("NYC");
+      await nycRef.set({"name": "NYC"});
+      var sfRef = ref.doc("SF");
+      await sfRef.set({"name": "SF", "population": 0});
+      var laRef = ref.doc("LA");
+      await laRef.set({"name": "LA"});
+
+      await _deleteCollection(firestore, ref);
+
+      var snapshot = await ref.get();
+      expect(snapshot.empty, isTrue);
+      expect(snapshot.docs.isEmpty, isTrue);
+    });
+
+    test("delete", () async {
+      var nycRef = ref.doc("NYC");
+      await nycRef.set({"name": "NYC"});
+
+      await nycRef.delete();
+      nycRef = ref.doc("NYC");
+
+      var snapshot = await nycRef.get();
+      expect(snapshot.exists, isFalse);
+    });
+
+    test('snapshot is equal', () async {
+      var aRef = ref.doc("a");
+      var bRef = ref.doc("b");
+
+      var a = await aRef.get();
+      var b = await aRef.get();
+      var c = await bRef.get();
+
+      expect(a.isEqual(b), isTrue);
+      expect(a.isEqual(c), isFalse);
+    });
+
+    test("delete fields", () async {
+      var nycRef = ref.doc("NYC");
+      await nycRef.set({"name": "New York", "population": 1000});
+
+      var snapshot = await nycRef.get();
+      var snapshotData = snapshot.data();
+      expect(snapshotData["name"], "New York");
+      expect(snapshotData["population"], 1000);
+
+      await nycRef.update(data: {"population": fs.FieldValue.delete()});
+
+      snapshot = await nycRef.get();
+      snapshotData = snapshot.data();
+      expect(snapshotData["name"], "New York");
+      expect(snapshotData["population"], isNull);
+    });
+
+    test("set document", () async {
+      var docRef = ref.doc("message1");
+      await docRef.set({"text": "Hi!"});
+
+      var snapshot = await docRef.get();
+      expect(snapshot.id, "message1");
+      expect(snapshot.exists, true);
+    });
+
+    test("set overwrites document", () async {
+      var docRef = ref.doc("message2");
+
+      await docRef.set({"text": "Message2"});
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(snapshotData, TypeMatcher<Map>());
+      expect(snapshotData["text"], "Message2");
+
+      await docRef.set({"title": "Ahoj"});
+      snapshot = await docRef.get();
+      snapshotData = snapshot.data();
+
+      expect(snapshotData["text"], isNull);
+      expect(snapshotData["title"], "Ahoj");
+    });
+
+    test("set with merge", () async {
+      var docRef = ref.doc("message3");
+
+      await docRef.set({"text": "Message3"});
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      await docRef.set(
+          {"text": "MessageNew", "title": "Ahoj"}, fs.SetOptions(merge: true));
+      snapshot = await docRef.get();
+      snapshotData = snapshot.data();
+
+      expect(snapshotData["text"], "MessageNew");
+      expect(snapshotData["title"], "Ahoj");
+    });
+
+    test('reference values', () async {
+      var ref = firestore.collection(testPath);
+      var mapValue = DateTime.now().toIso8601String();
+      var documentToReference = ref.doc("reference_target");
+      await documentToReference.set({'value': mapValue});
+
+      var docWithReference = ref.doc('doc');
+      await docWithReference.set({'ref': documentToReference});
+
+      var snapshot = await docWithReference.get();
+
+      Future validateValue(fs.DocumentReference ref) async {
+        var mySnap = await ref.get();
+        expect(mySnap.get('value'), mapValue);
+      }
+
+      await validateValue(snapshot.data()['ref'] as fs.DocumentReference);
+      await validateValue(snapshot.get('ref') as fs.DocumentReference);
+    });
+
+    group('validate simple types', () {
+      var map = <String, Object>{
+        "string": "Hello world!",
+        "bool": true,
+        "num": 3.14159265,
+        "array": [5, true, "hello"],
+        "null": null,
+        "map": {
+          "a": 5,
+          "b": {"nested": "foo"},
+          'toDateString': 'Regression for Date type detection'
+        },
+        "dateTime": DateTime.fromMillisecondsSinceEpoch(123456789),
+        "dateTimeUtc":
+            DateTime.fromMillisecondsSinceEpoch(123456789, isUtc: true),
+        "timestamp": fs.Timestamp.parse('2019-01-30T01:02:03.123456Z'),
+        'geoPoint': fs.GeoPoint(43.3247, -95.1500),
+        'blob - base64': fs.Blob.fromBase64String('AQIDBA=='),
+        'blob - bytes':
+            fs.Blob.fromUint8Array(Uint8List.fromList([1, 2, 3, 4])),
+      };
+
+      void expectSameGeo(fs.GeoPoint value, fs.GeoPoint expected) {
+        expect(value.latitude, expected.latitude);
+        expect(value.longitude, expected.longitude);
+      }
+
+      void expectSameMoment(fs.Timestamp value, DateTime expected) {
+        expect(value.toDateTime().isAtSameMomentAs(expected), isTrue,
+            reason: [
+              value,
+              'should be the same moment as',
+              expected.toUtc(),
+              '– ignoring timezone.'
+            ].join(' '));
+      }
+
+      for (var key in map.keys) {
+        final value = map[key];
+        test(key, () async {
+          var ref = firestore.collection(testPath);
+          var docRef = ref.doc("types");
+          await docRef.set({'value': value});
+          var snapshot = await docRef.get();
+
+          var snapshotDataValue = snapshot.data()['value'];
+          var snapshotGetValue = snapshot.get('value');
+
+          if (value is DateTime) {
+            expectSameMoment(snapshotDataValue, value);
+            expectSameMoment(snapshotGetValue, value);
+          } else if (key == 'geoPoint') {
+            // NOTE: `is` checks on interop objects always return true
+            expectSameGeo(snapshotDataValue, value);
+            expectSameGeo(snapshotGetValue, value);
+          } else if (key.startsWith('blob - ')) {
+            // NOTE: `is` checks on interop objects always return true
+            expect((snapshotDataValue as fs.Blob).isEqual(value), isTrue);
+            expect((snapshotGetValue as fs.Blob).isEqual(value), isTrue);
+          } else {
+            expect(snapshotDataValue, value);
+            expect(snapshotGetValue, value);
+          }
+        });
+      }
+    });
+
+    test('timestamp set/get', () async {
+      // We can write both
+      var dateTime = DateTime.parse('2018-10-30T01:02:03.789Z');
+      var timestamp = fs.Timestamp.parse('2018-10-31T01:02:03.123456Z');
+      var timestampNanos = fs.Timestamp.parse('2018-11-01T01:02:03.123456789Z');
+
+      var docRef = firestore.collection(testPath).doc('timestamp');
+
+      await docRef.set({
+        'dateTime': dateTime,
+        'timestamp': timestamp,
+        'timestampNanos': timestampNanos
+      });
+
+      // We read what we expect, i.e. always timestamp
+      expect((await docRef.get()).data(), {
+        'dateTime': fs.Timestamp.fromDateTime(dateTime),
+        'timestamp': timestamp,
+        // To note that currently we only have micros precision
+        'timestampNanos': fs.Timestamp(
+            timestampNanos.seconds, (timestampNanos.nanoseconds ~/ 1000) * 1000)
+      });
+    });
+
+    test("get field", () async {
+      var docRef = ref.doc("message4");
+
+      var map = {
+        "stringExample": "Hello world!",
+        "innerMap": {"someNumber": 3.14159265}
+      };
+
+      await docRef.set(map);
+      var snapshot = await docRef.get();
+
+      expect(snapshot.get("stringExample"), "Hello world!");
+      expect(snapshot.get("innerMap.someNumber"), 3.14159265);
+      expect(snapshot.get(fs.FieldPath("innerMap", "someNumber")), 3.14159265);
+      expect(snapshot.get("someNotExistentValue"), isNull);
+    });
+
+    test("add document", () async {
+      var docRef = await ref.add({"text": "MessageAdd"});
+
+      expect(docRef, isNotNull);
+      expect(docRef.id, isNotNull);
+      expect(docRef.parent.id, ref.id);
+    });
+
+    test("update document with Map", () async {
+      var docRef = await ref.add({"text": "Ahoj"});
+      await docRef.update(data: {"text": "Ahoj2"});
+
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(snapshotData["text"], "Ahoj2");
+
+      await docRef.update(data: {"text": "Ahoj", "text_en": "Hi"});
+
+      snapshot = await docRef.get();
+      snapshotData = snapshot.data();
+
+      expect(snapshotData["text"], "Ahoj");
+      expect(snapshotData["text_en"], "Hi");
+    });
+
+    test("update with serverTimestamp", () async {
+      var docRef = await ref.add({"text": "Good night"});
+      await docRef.update(data: {"timestamp": fs.FieldValue.serverTimestamp()});
+
+      var snapshot = await docRef.get();
+      var timeStamp = snapshot.data()['timestamp'];
+
+      expect(timeStamp, TypeMatcher<fs.Timestamp>());
+    });
+
+    test("update nested with dot notation", () async {
+      var docRef = await ref.add({
+        "greeting": {"text": "Good Morning"}
+      });
+      await docRef.update(data: {"greeting.text": "Good Morning after update"});
+
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(snapshotData["greeting"]["text"], "Good Morning after update");
+    });
+
+    test("update with FieldPath", () async {
+      var docRef = await ref.add({
+        "greeting": {"text": "Good Evening"}
+      });
+      await docRef.update(fieldsAndValues: [
+        fs.FieldPath("greeting", "text"),
+        "Good Evening after update",
+        fs.FieldPath("greeting", "text_cs"),
+        "Dobry vecer po uprave"
+      ]);
+
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(snapshotData["greeting"]["text"], "Good Evening after update");
+      expect(snapshotData["greeting"]["text_cs"], "Dobry vecer po uprave");
+    });
+
+    test("update with alternating fields as Strings and values", () async {
+      var docRef = await ref.add({
+        "greeting": {"text": "Hello"}
+      });
+      await docRef.update(fieldsAndValues: [
+        "greeting.text",
+        "Hello after update",
+        "greeting.text_cs",
+        "Ahoj po uprave"
+      ]);
+
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(snapshotData["greeting"]["text"], "Hello after update");
+      expect(snapshotData["greeting"]["text_cs"], "Ahoj po uprave");
+    });
+
+    test('array field value', () async {
+      var docRef = ref.doc('array_field_value');
+
+      // Make sure FieldValue class is exported by using it here
+      final fieldValueArrayUnion = fs.FieldValue.arrayUnion([1, 2]);
+      final fieldValueArrayUnion2 = fs.FieldValue.arrayUnion([10, 11]);
+      final fieldValueArrayComplex = fs.FieldValue.arrayUnion([
+        100,
+        "text",
+        {
+          'sub': [1]
+        },
+      ]);
+
+      // create document
+      var data = <String, dynamic>{
+        'array': fieldValueArrayUnion,
+        'array2': fieldValueArrayUnion2,
+        'complex': fieldValueArrayComplex
+      };
+
+      await docRef.set(data);
+
+      // read it
+      data = (await docRef.get()).data();
+      expect(data, {
+        'array': [1, 2],
+        'array2': [10, 11],
+        'complex': [
+          100,
+          'text',
+          {
+            'sub': [1]
+          },
+        ]
+      });
+
+      // update and remove some data
+      var updateData = {
+        'array': fs.FieldValue.arrayUnion([2, 3]),
+        'array2': fs.FieldValue.arrayRemove([11, 12]),
+        // try to remove a complex object
+        'complex': fs.FieldValue.arrayRemove([
+          100,
+          {
+            'sub': [1]
+          }
+        ])
+      };
+      await docRef.update(data: updateData);
+
+      // read again
+      data = (await docRef.get()).data();
+      expect(data, {
+        'array': [1, 2, 3],
+        'array2': [10],
+        'complex': [
+          'text',
+        ]
+      });
+    });
+
+    test("transaction", () async {
+      var docRef = ref.doc("message5");
+      await docRef.set({"text": "Hi"});
+
+      await firestore.runTransaction((transaction) async {
+        transaction.update(docRef, data: {"text": "Hi from transaction"});
+      });
+
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(snapshotData["text"], "Hi from transaction");
+    });
+
+    test("transaction returns updated value", () async {
+      var docRef = ref.doc("message6");
+      await docRef.set({"text": "Hi"});
+
+      var newValue = await firestore.runTransaction((transaction) async {
+        var documentSnapshot = await transaction.get(docRef);
+        var value = documentSnapshot.data()["text"] + " val from transaction";
+        transaction.update(docRef, data: {"text": value});
+        return value;
+      });
+
+      expect(newValue, "Hi val from transaction");
+
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(snapshotData["text"], newValue);
+    });
+
+    test("transaction fails", () async {
+      // update is before get -> transaction fails
+      var docRef = ref.doc("message7");
+      await docRef.set({"text": "Hi"});
+
+      expect(firestore.runTransaction((transaction) async {
+        transaction.update(docRef, data: {"text": "Some value"});
+        await transaction.get(docRef);
+      }),
+          throwsToString(
+              contains('Transactions lookups are invalid after writes.')));
+    });
+
+    test("transaction with FieldPath", () async {
+      var docRef = ref.doc("message8");
+      await docRef.set({
+        "description": {"text": "Good morning!!!"}
+      });
+
+      await firestore.runTransaction((transaction) async {
+        transaction.update(docRef, fieldsAndValues: [
+          fs.FieldPath("description", "text"),
+          "Good morning after update!!!",
+          fs.FieldPath("description", "text_cs"),
+          "Dobre rano po uprave!!!"
+        ]);
+      });
+
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(
+          snapshotData["description"]["text"], "Good morning after update!!!");
+      expect(snapshotData["description"]["text_cs"], "Dobre rano po uprave!!!");
+    });
+
+    test("transaction with alternating fields as Strings and values", () async {
+      var docRef = ref.doc("message8");
+      await docRef.set({
+        "description": {"text": "Good morning!!!"}
+      });
+
+      await firestore.runTransaction((transaction) async {
+        transaction.update(docRef, fieldsAndValues: [
+          "description.text",
+          "Good morning after update!!!",
+          "description.text_cs",
+          "Dobre rano po uprave!!!"
+        ]);
+      });
+
+      var snapshot = await docRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(
+          snapshotData["description"]["text"], "Good morning after update!!!");
+      expect(snapshotData["description"]["text_cs"], "Dobre rano po uprave!!!");
+    });
+
+    test("WriteBatch operations", () async {
+      var nycRef = ref.doc("NYC");
+      await nycRef.set({"name": "NYC"});
+      var sfRef = ref.doc("SF");
+      await sfRef.set({"name": "SF", "population": 0});
+      var laRef = ref.doc("LA");
+      await laRef.set({"name": "LA"});
+
+      var collectionSnapshot = await ref.get();
+      expect(collectionSnapshot.size, 3);
+
+      var batch = firestore.batch();
+      batch.set(nycRef, {"name": "New York"});
+      batch.update(sfRef, data: {"population": 1000000});
+      batch.delete(laRef);
+      await batch.commit();
+
+      var snapshot = await nycRef.get();
+      var snapshotData = snapshot.data();
+      expect(snapshotData["name"], "New York");
+
+      snapshot = await sfRef.get();
+      snapshotData = snapshot.data();
+      expect(snapshotData["population"], 1000000);
+
+      collectionSnapshot = await ref.get();
+      expect(collectionSnapshot.size, 2);
+    });
+
+    test("WriteBatch operations with FieldPath", () async {
+      var sfRef = ref.doc("SF");
+      await sfRef.set({
+        "name": {"short": "SF"},
+        "population": 0
+      });
+
+      var batch = firestore.batch();
+      batch.update(sfRef, fieldsAndValues: [
+        fs.FieldPath("name", "long"),
+        "San Francisco",
+        fs.FieldPath("population"),
+        1000000
+      ]);
+      await batch.commit();
+
+      var snapshot = await sfRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(snapshotData["name"]["long"], "San Francisco");
+      expect(snapshotData["population"], 1000000);
+    });
+
+    test("WriteBatch with alternating fields as Strings and values", () async {
+      var sfRef = ref.doc("SF");
+      await sfRef.set({
+        "name": {"short": "SF"},
+        "population": 0
+      });
+
+      var batch = firestore.batch();
+      batch.update(sfRef, fieldsAndValues: [
+        "name.long",
+        "San Francisco",
+        "population",
+        1000000
+      ]);
+      await batch.commit();
+
+      var snapshot = await sfRef.get();
+      var snapshotData = snapshot.data();
+
+      expect(snapshotData["name"]["long"], "San Francisco");
+      expect(snapshotData["population"], 1000000);
+    });
+  });
+
+  test('metadata docChanges', () async {
+    var ref = firestore.collection('$testPath/with/index');
+
+    await _deleteCollection(firestore, ref);
+
+    var count = 0;
+    ref.onSnapshotMetadata.listen(expectAsync1((qs) {
+      count++;
+      var metadata = qs.metadata;
+      var changes = qs.docChanges();
+      switch (count) {
+        case 1:
+          expect(changes.single.type, 'added');
+          expect(changes.single.doc.data()['value'], isNull);
+          expect(metadata.hasPendingWrites, isTrue);
+          expect(metadata.fromCache, isTrue);
+          return;
+        case 2:
+          expect(changes, isEmpty);
+          expect(metadata.hasPendingWrites, isTrue);
+          expect(metadata.fromCache, isFalse);
+          return;
+        case 3:
+          expect(changes.single.type, 'modified');
+          expect(
+              changes.single.doc.data()['value'], TypeMatcher<fs.Timestamp>());
+          expect(metadata.hasPendingWrites, isFalse);
+          expect(metadata.fromCache, isFalse);
+          return;
+      }
+      fail('should never get here!');
+    }, count: 3));
+
+    // ignore: unawaited_futures
+    ref.doc("message1").set({'value': fs.FieldValue.serverTimestamp()});
+  }, timeout: Timeout.parse('10s'), retry: 3);
+
+  group("Quering data", () {
+    fs.CollectionReference ref;
+
+    setUp(() async {
+      ref = firestore.collection('$testPath/with/index');
+
+      await _deleteCollection(firestore, ref);
+
+      await ref
+          .doc("message1")
+          .set({"text": "hello", "lang": "en", "new": true});
+      await ref.doc("message2").set({
+        "text": "hi",
+        "lang": "en",
+        "description": {"text": "description text"}
+      });
+      await ref
+          .doc("message3")
+          .set({"text": "ahoj", "lang": "cs", "new": true});
+      await ref.doc("message4").set({"text": "cau", "lang": "cs"});
+    });
+
+    tearDown(() async {
+      if (ref != null) {
+        await _deleteCollection(firestore, ref);
+        ref = null;
+      }
+    });
+
+    test("get document data", () async {
+      var docRef = ref.doc("message1");
+      var snapshot = await docRef.get();
+      expect(snapshot, isNotNull);
+      expect(snapshot.exists, isTrue);
+
+      var data = snapshot.data();
+      expect(data, isNotNull);
+      expect(data["text"], "hello");
+    });
+
+    test("get nonexistent document", () async {
+      var docRef = ref.doc("message0");
+      var snapshot = await docRef.get();
+      expect(snapshot.exists, isFalse);
+    });
+
+    test("get documents where", () async {
+      var snapshot = await ref.where("new", "==", true).get();
+      expect(snapshot.size, 2);
+    });
+
+    test("get documents where with FieldPath", () async {
+      var snapshot = await ref.where(fs.FieldPath("new"), "==", true).get();
+      expect(snapshot.size, 2);
+    });
+
+    test("get documents using compound query", () async {
+      var snapshot =
+          await ref.where("new", "==", true).where("text", "==", "hello").get();
+      expect(snapshot.size, 1);
+      expect(snapshot.docs.length, 1);
+      expect(snapshot.docs[0].data()["text"], "hello");
+    });
+
+    test("query snapshot is equal", () async {
+      var snapshotA =
+          await ref.where("new", "==", true).where("text", "==", "hello").get();
+      var snapshotB =
+          await ref.where("new", "==", true).where("text", "==", "hello").get();
+      var snapshotC = await ref
+          .where("new", "==", false)
+          .where("text", "==", "hello")
+          .get();
+
+      expect(snapshotA.isEqual(snapshotB), isTrue);
+      expect(snapshotA.isEqual(snapshotC), isFalse);
+    });
+
+    test("get all documents", () async {
+      var snapshot = await ref.get();
+      expect(snapshot.size, 4);
+      expect(snapshot.docs, isNotEmpty);
+      expect(snapshot.docs.length, snapshot.size);
+      expect(
+          snapshot.docs[0].data()["text"], anyOf("hello", "hi", "ahoj", "cau"));
+    });
+
+    group('onSnapshot', () {
+      test("from ref", () async {
+        var snapshot = await ref.onSnapshot.first;
+
+        var size = snapshot.docs.length;
+        expect(size, inInclusiveRange(1, 4));
+
+        expect(snapshot.docChanges(), hasLength(size));
+
+        var forEachCount = 0;
+        snapshot.forEach((doc) {
+          forEachCount++;
+          expect(doc.id, anyOf("message1", "message2", "message3", "message4"));
+          expect(doc.metadata, isNotNull);
+        });
+        expect(forEachCount, size);
+
+        for (var change in snapshot.docChanges()) {
+          if (change.type == "added") {
+            expect(change.doc.id,
+                anyOf("message1", "message2", "message3", "message4"));
+          }
+        }
+      });
+
+      test("from ref.doc", () async {
+        var doc = await ref.doc("message1").onSnapshot.first;
+        expect(doc.exists, isTrue);
+        expect(doc.data()["text"], "hello");
+      });
+
+      test('normal', () async {
+        var events = await ref.onSnapshot.take(4).toList();
+        expect(
+            events,
+            everyElement(TypeMatcher<fs.QuerySnapshot>()
+                .having(
+                    (qs) => qs.metadata.fromCache, 'metadata.fromCache', isTrue)
+                .having((qs) => qs.metadata.hasPendingWrites,
+                    'metadata.hasPendingWrites', isFalse)
+                .having((qs) => qs.docChanges(), 'docChanges', hasLength(1))));
+      });
+
+      test('metadata', () async {
+        var events = await ref.onSnapshotMetadata.take(5).toList();
+        expect(events.last.metadata.hasPendingWrites, isFalse);
+        expect(events.last.docChanges(), isEmpty);
+      });
+    });
+
+    test("order by", () async {
+      var snapshot = await ref.orderBy("text").get();
+
+      expect(snapshot.size, 4);
+      expect(snapshot.docs[0].data()["text"], "ahoj");
+      expect(snapshot.docs[3].data()["text"], "hi");
+
+      snapshot = await ref.orderBy("text", "desc").get();
+
+      expect(snapshot.size, 4);
+      expect(snapshot.docs[0].data()["text"], "hi");
+      expect(snapshot.docs[3].data()["text"], "ahoj");
+    });
+
+    test("limit", () async {
+      var snapshot = await ref.get();
+      expect(snapshot.size, 4);
+
+      snapshot = await ref.limit(2).get();
+      expect(snapshot.size, 2);
+    });
+
+    test("get documents where with limit", () async {
+      var snapshot = await ref.where("new", "==", true).limit(1).get();
+      expect(snapshot.size, 1);
+    });
+
+    // !!!IMPORTANT: You need to build index for lang and text under `index`
+    // collection to be able to run these tests.
+    // (You can do this in Firebase console)
+    test("startAt", () async {
+      var snapshot = await ref
+          .orderBy("lang")
+          .orderBy("text")
+          .startAt(fieldValues: ["cs", "cau"]).get();
+      expect(snapshot.size, 3);
+      expect(snapshot.docs[0].data()["text"], "cau");
+      expect(snapshot.docs[2].data()["text"], "hi");
+
+      snapshot = await ref.orderBy("description").startAt(fieldValues: [
+        {"text": "description text"}
+      ]).get();
+
+      expect(snapshot.size, 1);
+      expect(
+          snapshot.docs[0].data()["description"], {"text": "description text"});
+
+      var message2Snapshot = await ref.doc("message2").get();
+      snapshot =
+          await ref.orderBy("text").startAt(snapshot: message2Snapshot).get();
+
+      // message2 text = "hi" => it is the last one
+      expect(snapshot.size, 1);
+      expect(snapshot.docs[0].data()["text"], "hi");
+    });
+
+    test("startAfter", () async {
+      var snapshot = await ref
+          .orderBy("lang")
+          .orderBy("text")
+          .startAfter(fieldValues: ["cs", "cau"]).get();
+      expect(snapshot.size, 2);
+      expect(snapshot.docs[0].data()["text"], "hello");
+      expect(snapshot.docs[1].data()["text"], "hi");
+
+      snapshot = await ref.orderBy("description").startAfter(fieldValues: [
+        {"text": "description text"}
+      ]).get();
+
+      expect(snapshot.empty, isTrue);
+
+      var message2Snapshot = await ref.doc("message2").get();
+      snapshot = await ref
+          .orderBy("text")
+          .startAfter(snapshot: message2Snapshot)
+          .get();
+
+      // message2 text = "hi"
+      expect(snapshot.empty, isTrue);
+    });
+
+    test("endBefore", () async {
+      var snapshot = await ref
+          .orderBy("lang")
+          .orderBy("text")
+          .endBefore(fieldValues: ["en", "hello"]).get();
+      expect(snapshot.size, 2);
+      expect(snapshot.docs[0].data()["text"], "ahoj");
+      expect(snapshot.docs[1].data()["text"], "cau");
+
+      snapshot = await ref.orderBy("description").endBefore(fieldValues: [
+        {"text": "description text"}
+      ]).get();
+
+      expect(snapshot.empty, isTrue);
+
+      var message2Snapshot = await ref.doc("message2").get();
+      snapshot =
+          await ref.orderBy("text").endBefore(snapshot: message2Snapshot).get();
+
+      // message2 text = "hi"
+      expect(snapshot.size, 3);
+      expect(snapshot.docs[0].data()["text"], "ahoj");
+      expect(snapshot.docs[2].data()["text"], "hello");
+    });
+
+    test("endAt", () async {
+      var snapshot = await ref
+          .orderBy("lang")
+          .orderBy("text")
+          .endAt(fieldValues: ["en", "hello"]).get();
+      expect(snapshot.size, 3);
+      expect(snapshot.docs[0].data()["text"], "ahoj");
+      expect(snapshot.docs[2].data()["text"], "hello");
+
+      snapshot = await ref.orderBy("description").endAt(fieldValues: [
+        {"text": "description text"}
+      ]).get();
+
+      expect(snapshot.size, 1);
+      expect(
+          snapshot.docs[0].data()["description"], {"text": "description text"});
+
+      var message2Snapshot = await ref.doc("message2").get();
+      snapshot =
+          await ref.orderBy("text").endAt(snapshot: message2Snapshot).get();
+
+      // message2 text = "hi"
+      expect(snapshot.size, 4);
+      expect(snapshot.docs[0].data()["text"], "ahoj");
+      expect(snapshot.docs[3].data()["text"], "hi");
+    });
+  });
+}

--- a/test/firestore_with_timestamp_test.html
+++ b/test/firestore_with_timestamp_test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Firestore Test</title>
+</head>
+<body>
+<script src="https://www.gstatic.com/firebasejs/5.5.2/firebase-app.js"></script>
+<script src="https://www.gstatic.com/firebasejs/5.5.2/firebase-firestore.js"></script>
+<script src="packages/test/dart.js"></script>
+<link rel="x-dart-test" href="firestore_with_timestamp_test.dart">
+</body>
+</html>

--- a/test/timestamp_test.dart
+++ b/test/timestamp_test.dart
@@ -1,0 +1,172 @@
+import 'package:firebase/src/timestamp.dart';
+import 'package:test/test.dart';
+
+// Use this test to properly test on all platform
+// pub run test -p chrome,node,vm,firefox .\test\timestamp_test.dart
+bool get _runningAsJavascript => identical(1, 1.0);
+
+main() {
+  group('timestamp', () {
+    test('equals', () {
+      expect(Timestamp(1, 2), Timestamp(1, 2));
+      expect(Timestamp(1, 2), isNot(Timestamp(1, 3)));
+      expect(Timestamp(1, 2), isNot(Timestamp(0, 2)));
+    });
+    test('compareTo', () {
+      expect(Timestamp(1, 2).compareTo(Timestamp(1, 2)), 0);
+      expect(Timestamp(1, 2).compareTo(Timestamp(1, 3)), lessThan(0));
+      expect(Timestamp(1, 2).compareTo(Timestamp(2, 2)), lessThan(0));
+      expect(Timestamp(1, 2).compareTo(Timestamp(1, 1)), greaterThan(0));
+      expect(Timestamp(1, 2).compareTo(Timestamp(0, 2)), greaterThan(0));
+    });
+    test('millisecondsSinceEpoch', () {
+      var now = Timestamp(1, 1);
+      expect(
+          now.millisecondsSinceEpoch, now.toDateTime().millisecondsSinceEpoch);
+      now = Timestamp.fromMillisecondsSinceEpoch(now.millisecondsSinceEpoch);
+      expect(
+          now.millisecondsSinceEpoch, now.toDateTime().millisecondsSinceEpoch);
+    });
+
+    test('equals', () {
+      expect(Timestamp(1, 2), Timestamp(1, 2));
+      expect(Timestamp(1, 2), isNot(Timestamp(1, 3)));
+      expect(Timestamp(1, 2), isNot(Timestamp(0, 2)));
+    });
+    test('compareTo', () {
+      expect(Timestamp(1, 2).compareTo(Timestamp(1, 2)), 0);
+      expect(Timestamp(1, 2).compareTo(Timestamp(1, 3)), lessThan(0));
+      expect(Timestamp(1, 2).compareTo(Timestamp(2, 2)), lessThan(0));
+      expect(Timestamp(1, 2).compareTo(Timestamp(1, 1)), greaterThan(0));
+      expect(Timestamp(1, 2).compareTo(Timestamp(0, 2)), greaterThan(0));
+    });
+
+    _checkToIso8601(
+        Timestamp timestamp,
+        String expectedTimestampToIso8601String,
+        String expectedDateTimeToIso8601String) {
+      var reason = '${timestamp.seconds} s ${timestamp.nanoseconds} ns';
+      expect(timestamp.toIso8601String(), expectedTimestampToIso8601String,
+          reason: 'timestamp $reason');
+      expect(timestamp.toDateTime(isUtc: true).toIso8601String(),
+          expectedDateTimeToIso8601String,
+          reason: 'dateTime $reason');
+    }
+
+    test('toIso8601', () {
+      _checkToIso8601(Timestamp(0, 0), '1970-01-01T00:00:00.000Z',
+          '1970-01-01T00:00:00.000Z');
+      _checkToIso8601(Timestamp(0, 100000000), '1970-01-01T00:00:00.100Z',
+          '1970-01-01T00:00:00.100Z');
+      _checkToIso8601(
+        Timestamp(0, 100000),
+        '1970-01-01T00:00:00.000100Z',
+        _runningAsJavascript
+            ? '1970-01-01T00:00:00.000Z'
+            : '1970-01-01T00:00:00.000100Z',
+      );
+      _checkToIso8601(
+        Timestamp(0, 100),
+        '1970-01-01T00:00:00.000000100Z',
+        _runningAsJavascript
+            ? '1970-01-01T00:00:00.000Z'
+            : '1970-01-01T00:00:00.000Z',
+      );
+      _checkToIso8601(
+        Timestamp(0, 999999999),
+        '1970-01-01T00:00:00.999999999Z',
+        _runningAsJavascript
+            ? '1970-01-01T00:00:01.000Z' // Precision issue
+            : '1970-01-01T00:00:00.999999Z',
+      );
+    });
+
+    test('limit', () {
+      Timestamp(-62135596800, 0);
+      Timestamp(253402300799, 999999999);
+
+      expect(() => Timestamp(-62135596801, 0), throwsArgumentError);
+      expect(() => Timestamp(253402300800, 0), throwsArgumentError);
+      expect(() => Timestamp(0, -1), throwsArgumentError);
+      expect(() => Timestamp(0, 1000000000), throwsArgumentError);
+    });
+    test('parse', () {
+      _checkParse(
+        String text,
+        String expectedTimestampToIso8601String,
+        String expectedDateTimeToIso8601String,
+      ) {
+        var timestamp = Timestamp.parse(text);
+        return _checkToIso8601(timestamp, expectedTimestampToIso8601String,
+            expectedDateTimeToIso8601String);
+      }
+
+      _checkParseSecondsNanos(
+          String text, int expectedSeconds, int expectedNanos) {
+        var timestamp = Timestamp.parse(text);
+        expect(timestamp.seconds, expectedSeconds, reason: text);
+        expect(timestamp.nanoseconds, expectedNanos, reason: text);
+      }
+
+      _checkParse(
+          '2018-10-20T05:13:45.985343123Z',
+          '2018-10-20T05:13:45.985343123Z',
+          _runningAsJavascript
+              ? '2018-10-20T05:13:45.985Z'
+              : '2018-10-20T05:13:45.985343Z');
+      _checkParse(
+          '2018-10-20T05:13:45.98534312Z',
+          '2018-10-20T05:13:45.985343120Z',
+          _runningAsJavascript
+              ? '2018-10-20T05:13:45.985Z'
+              : '2018-10-20T05:13:45.985343Z');
+      _checkParse(
+          '2018-10-20T05:13:45.985343Z',
+          '2018-10-20T05:13:45.985343Z',
+          _runningAsJavascript
+              ? '2018-10-20T05:13:45.985Z'
+              : '2018-10-20T05:13:45.985343Z');
+      _checkParse('2018-10-20T05:13:45.985Z', '2018-10-20T05:13:45.985Z',
+          '2018-10-20T05:13:45.985Z');
+      _checkParse('1234-01-23T01:23:45.123Z', '1234-01-23T01:23:45.123Z',
+          '1234-01-23T01:23:45.123Z');
+      _checkParse('2018-10-20T05:13:45Z', '2018-10-20T05:13:45.000Z',
+          '2018-10-20T05:13:45.000Z');
+      _checkParse('2018-10-20T05:13Z', '2018-10-20T05:13:00.000Z',
+          '2018-10-20T05:13:00.000Z');
+      _checkParse('2018-10-20T05Z', '2018-10-20T05:00:00.000Z',
+          '2018-10-20T05:00:00.000Z');
+
+      // 10 digits ignored!
+      _checkParse(
+          '2018-10-20T05:13:45.9853431239Z',
+          '2018-10-20T05:13:45.985343123Z',
+          _runningAsJavascript
+              ? '2018-10-20T05:13:45.985Z'
+              : '2018-10-20T05:13:45.985343Z');
+
+      // Limit
+      _checkParse('0001-01-01T00:00:00Z', '0001-01-01T00:00:00.000Z',
+          '0001-01-01T00:00:00.000Z');
+      _checkParse(
+          '9999-12-31T23:59:59.999999999Z',
+          '9999-12-31T23:59:59.999999999Z',
+          _runningAsJavascript
+              ? '+010000-01-01T00:00:00.000Z' // Precision issue
+              : '9999-12-31T23:59:59.999999Z');
+      // Parse local converted to utc
+      expect(Timestamp.tryParse('2018-10-20T05:13:45.985').toIso8601String(),
+          endsWith('.985Z'));
+      expect(Timestamp.tryParse('2018-10-20T05:13:45.985123').toIso8601String(),
+          endsWith('.985123Z'));
+      expect(
+          Timestamp.tryParse('2018-10-20T05:13:45.985123100').toIso8601String(),
+          endsWith('.985123100Z'));
+
+      // Limit
+      _checkParseSecondsNanos('0001-01-01T00:00:00Z', -62135596800, 0);
+      _checkParseSecondsNanos(
+          '9999-12-31T23:59:59.999999999Z', 253402300799, 999999999);
+    });
+  });
+}


### PR DESCRIPTION
So I perform a new change based on what I did before.

As a proof of being backward compatible, I kept the existing `firestore_test.dart` as is. It sill works but firebase shows warning message to switch to timestamp. There was a bug in dartifyDate that prevented converting js date.

Time to migrate to Timestamp using `firestore.setting(timestampsInSnapshots:true)`!
`firestore_with_timestamp_test.dart` is a copy of `firestore_test.dart` with timestamps enables. No more warning.

A better solution could be found however firebase urge to switch to timestamp and it was currently impossible.