### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  http: '>=0.11.3 <0.13.0'
+  http: ^0.12.0
   js: ^0.6.0
 
 dev_dependencies:


### PR DESCRIPTION
I am using Algolia package in my angular dart application and because every version of algolia depends on http ^0.12.0 and firebase depends on http ^0.11.0 then algolia becomes incompatible with firebase.