### PR TITLE
Support storage list API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   will have to include their own polyfil for `Promise`. 
 
 - Added `FieldValue.increment` static function.
+- Added support for storage List API.
 
 ## 5.0.4
 

--- a/README.md
+++ b/README.md
@@ -247,10 +247,13 @@ See [more info](#do-you-need-to-use-firestore).
 ### Storage tests and example
 
 Storage tests and example need to have **public rules** to be able to read and
-write to storage. Update your rules in Firebase console, `Storage/Rules` section
+write to storage. Firebase Storage Rules Version 2 is
+[required](https://firebase.google.com/docs/storage/web/list-files) for `list` and 
+`listAll`. Update your rules in Firebase console, `Storage/Rules` section
 to:
 
 ```
+rules_version = '2';
 service firebase.storage {
   match /b/YOUR_STORAGE_BUCKET_URL/o {
     match /{allPaths=**} {

--- a/lib/src/interop/storage_interop.dart
+++ b/lib/src/interop/storage_interop.dart
@@ -41,6 +41,8 @@ abstract class ReferenceJsImpl {
   external PromiseJsImpl delete();
   external PromiseJsImpl<String> getDownloadURL();
   external PromiseJsImpl<FullMetadataJsImpl> getMetadata();
+  external PromiseJsImpl<ListResultJsImpl> list([ListOptionsJsImpl options]);
+  external PromiseJsImpl<ListResultJsImpl> listAll();
   external UploadTaskJsImpl put(blob, [UploadMetadataJsImpl metadata]);
   external UploadTaskJsImpl putString(String value,
       [String format, UploadMetadataJsImpl metadata]);
@@ -136,6 +138,25 @@ class SettableMetadataJsImpl {
       String contentLanguage,
       String contentType,
       dynamic customMetadata});
+}
+
+@JS()
+@anonymous
+class ListOptionsJsImpl {
+  external set maxResults(int s);
+  external int get maxResults;
+  external set pageToken(String s);
+  external String get pageToken;
+
+  external factory ListOptionsJsImpl({int maxResults, String pageToken});
+}
+
+@JS()
+@anonymous
+class ListResultJsImpl {
+  external List<ReferenceJsImpl> get items;
+  external String get nextPageToken;
+  external List<ReferenceJsImpl> get prefixes;
 }
 
 /// An enumeration of the possible string formats for upload.


### PR DESCRIPTION
Sorry for the mess!

Only important thing to note is that using the List API (and thus testing it) requires updating storage rules to version 2.

```
rules_version = '2';
service firebase.storage {
  ...
}
```