### PR TITLE
Feature: Messaging.isSupported()

### DIFF
--- a/lib/src/interop/messaging_interop.dart
+++ b/lib/src/interop/messaging_interop.dart
@@ -6,6 +6,9 @@ import 'package:js/js.dart';
 import '../func.dart';
 import 'es6_interop.dart';
 
+@JS('isSupported')
+external bool isSupported();
+
 @JS('Messaging')
 abstract class MessagingJsImpl {
   external void usePublicVapidKey(String key);

--- a/lib/src/messaging.dart
+++ b/lib/src/messaging.dart
@@ -16,6 +16,8 @@ class Messaging extends JsObjectWrapper<messaging_interop.MessagingJsImpl> {
     return _expando[jsObject] ??= Messaging._fromJsObject(jsObject);
   }
 
+  static bool isSupported() => messaging_interop.isSupported();
+
   Messaging._fromJsObject(messaging_interop.MessagingJsImpl jsObject)
       : super.fromJsObject(jsObject);
 


### PR DESCRIPTION
According to Firebase docs -- firebase. messaging:
Functions
isSupported
isSupported(): boolean
Returns boolean

The function is accessed in js by firebase.messaging.isSupported(), here as a static member of the Messaging class (Messaging.isSupported()).
There are no tests for Messaging.

Dart VM version: 2.4.0 (Wed Jun 19 11:53:45 2019 +0200) on "windows_x64"