### PR TITLE
Support firestore collectionGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `serverResponse` getter to `FirebaseError`.
 - Added `FieldValue.increment` static function.
 - Added support for storage List API.
+- Added support for firestore collectionGroup
 
 ## 5.0.4
 

--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -53,6 +53,16 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
   CollectionReference collection(String collectionPath) =>
       CollectionReference.getInstance(jsObject.collection(collectionPath));
 
+  /// Creates and returns a new [Query] that includes all documents in the
+  /// database that are contained in a collection or subcollection with
+  /// the given collectionId.
+  ///
+  /// The collectionId identifies the collections to query over. Every
+  /// collection or subcollection with this ID as the last segment of
+  /// its path will be included. Cannot contain a slash.
+  Query collectionGroup(String collectionId) =>
+      Query.fromJsObject(jsObject.collectionGroup(collectionId));
+
   /// Gets a [DocumentReference] instance that refers to
   /// the document at the specified path.
   /// The [documentPath] parameter is a slash-separated path to a document.

--- a/lib/src/interop/firestore_interop.dart
+++ b/lib/src/interop/firestore_interop.dart
@@ -30,6 +30,7 @@ abstract class FirestoreJsImpl {
   external set app(AppJsImpl a);
   external WriteBatchJsImpl batch();
   external CollectionReferenceJsImpl collection(String collectionPath);
+  external QueryJsImpl collectionGroup(String collectionId);
   external DocumentReferenceJsImpl doc(String documentPath);
   external PromiseJsImpl<Null> enablePersistence();
   external PromiseJsImpl runTransaction(

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -872,6 +872,15 @@ void main() {
           snapshot.docs[0].data()["text"], anyOf("hello", "hi", "ahoj", "cau"));
     });
 
+    test("collectionGroup", () async {
+      var group = firestore.collectionGroup("index");
+      var snapshot = await group.get();
+
+      expect(snapshot.size, 4);
+      expect(snapshot.docs.map((d) => d.ref.path),
+          everyElement(contains("index")));
+    });
+
     group('onSnapshot', () {
       test("from ref", () async {
         var snapshot = await ref.onSnapshot.first;


### PR DESCRIPTION
Executing queries on collection groups [requires](https://firebase.google.com/docs/firestore/security/rules-query#collection_group_queries_and_security_rules) rules version 2 and indexes with group queries specifically enabled. However, they're just normal queries as far as interop is concerned so I don't think  they need any additional test coverage. 

Closes #223 