### PR TITLE
Added firestore interop options to settings to work with Emulator Suite

### DIFF
--- a/lib/src/interop/firestore_interop.dart
+++ b/lib/src/interop/firestore_interop.dart
@@ -323,8 +323,11 @@ abstract class SnapshotListenOptions {
 abstract class Settings {
   external bool get timestampsInSnapshots;
   external set timestampsInSnapshots(bool v);
+  external set cacheSizeBytes(int i);
+  external set host(String h);
+  external set ssl(bool v);
 
-  external factory Settings({bool timestampsInSnapshots});
+  external factory Settings({bool timestampsInSnapshots, int cacheSizeBytes, String host, bool ssl});
 }
 
 /// Metadata about a snapshot, describing the state of the snapshot.


### PR DESCRIPTION
Added the missing options from [Settings](https://firebase.google.com/docs/reference/js/firebase.firestore.Settings) to allow usage of [Emulator Suite](https://firebase.google.com/docs/emulator-suite)