### PR TITLE
docs: fix 404 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
   been working on unofficial wrappers.
   * [package:firebase_admin_interop](https://pub.dev/packages/firebase_admin_interop)
   * [package:firebase_functions_interop](https://pub.dev/packages/firebase_functions_interop)
-  * [package:firestore_interop](https://pub.dev/packages/firebase_functions_interop)
 
 ## Firebase Configuration
 You can find more information on how to use Firebase on the

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@
 
 * Flutter: [FlutterFire plugins](https://github.com/flutter/plugins/blob/master/FlutterFire.md)
 
+* Node (via dart2js): [Anatoly Pulyaevskiy](https://github.com/pulyaevskiy) has
+  been working on unofficial wrappers.
+  * [package:firebase_admin_interop](https://pub.dev/packages/firebase_admin_interop)
+  * [package:firebase_functions_interop](https://pub.dev/packages/firebase_functions_interop)
+  * [package:firestore_interop](https://pub.dev/packages/firebase_functions_interop)
+
 ## Firebase Configuration
 You can find more information on how to use Firebase on the
 [Getting started](https://firebase.google.com/docs/web/setup) page.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@
 
 * Flutter: [FlutterFire plugins](https://github.com/flutter/plugins/blob/master/FlutterFire.md)
 
-* Node (via dart2js): [Anatoly Pulyaevskiy](https://github.com/pulyaevskiy) has
-  been working on unofficial wrappers.
-  * [package:firebase_admin_interop](https://pub.dev/packages/packages/firebase_admin_interop)
-  * [package:firebase_functions_interop](https://pub.dev/packages/packages/firebase_functions_interop)
-  * [package:firestore_interop](https://pub.dev/packages/packages/firestore_interop)
-
 ## Firebase Configuration
 You can find more information on how to use Firebase on the
 [Getting started](https://firebase.google.com/docs/web/setup) page.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase
 description: Firebase libraries for Dart on the web and server
-version: 8.0.0-dev+1
+version: 8.0.0-dev
 homepage: https://github.com/FirebaseExtended/firebase-dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase
 description: Firebase libraries for Dart on the web and server
-version: 8.0.0-dev
-homepage: https://github.com/FirebaseExtended/firebase-dart/firebase-dart
+version: 8.0.0-dev+1
+homepage: https://github.com/FirebaseExtended/firebase-dart
 
 environment:
   sdk: '>=2.7.0-dev <3.0.0'


### PR DESCRIPTION
These links in the README were 404ing. If those projects have been deleted/discontinued we should remove them (this PR)

If they have moved/merged into different projects, let me know I can update the links instead of removing them.