### PR TITLE
Enabled sending of user properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.2.2
+## 7.2.2-dev
 
 - Enabled sending of user properties in analytics with `setUserProperties`.
 - Removed unused (and unusable) `CustomParams` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.2.2
 
-- Enabled sending of user properties in analytics with `setUserProperties`
+- Enabled sending of user properties in analytics with `setUserProperties`.
+- Removed unused (and unusable) `CustomParams` class.
 
 ## 7.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.2
+
+- Enabled sending of user properties in analytics with `setUserProperties`
+
 ## 7.2.1
 
 - Mark intereop types `AuthProvider` and `OAuthCredential` anonymous. 

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -44,12 +44,12 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
     }
   }
 
-  void setUserProperties(CustomParams properties,
+  void setUserProperties(Map<String, String> properties,
       [AnalyticsCallOptions options]) {
     if (options != null) {
-      jsObject.setUserProperties(properties.jsObject, options.jsObject);
+      jsObject.setUserProperties(jsify(properties), options.jsObject);
     } else {
-      jsObject.setUserProperties(properties.jsObject);
+      jsObject.setUserProperties(jsify(properties));
     }
   }
 }

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -65,9 +65,3 @@ class AnalyticsCallOptions
     jsObject.global = t;
   }
 }
-
-class CustomParams
-    extends JsObjectWrapper<analytics_interop.CustomParamsJsImpl> {
-  CustomParams._fromJsObject(analytics_interop.CustomParamsJsImpl jsObject)
-      : super.fromJsObject(jsObject);
-}

--- a/lib/src/interop/analytics_interop.dart
+++ b/lib/src/interop/analytics_interop.dart
@@ -11,7 +11,7 @@ abstract class AnalyticsJsImpl {
   external void setCurrentScreen(String screenName,
       [AnalyticsCallOptionsJsImpl options]);
   external void setUserId(String id, [AnalyticsCallOptionsJsImpl options]);
-  external void setUserProperties(CustomParamsJsImpl properties,
+  external void setUserProperties(Object properties,
       [AnalyticsCallOptionsJsImpl options]);
 }
 

--- a/lib/src/interop/analytics_interop.dart
+++ b/lib/src/interop/analytics_interop.dart
@@ -23,8 +23,3 @@ class AnalyticsCallOptionsJsImpl {
 
   external factory AnalyticsCallOptionsJsImpl({bool global});
 }
-
-@JS('CustomParams')
-class CustomParamsJsImpl {
-  //TODO: implement
-}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase
 description: Firebase libraries for Dart on the web and server
-version: 7.2.1
+version: 7.2.2
 homepage: https://github.com/FirebaseExtended/firebase-dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase
 description: Firebase libraries for Dart on the web and server
-version: 7.2.2
+version: 7.2.2-dev
 homepage: https://github.com/FirebaseExtended/firebase-dart
 
 environment:


### PR DESCRIPTION
Fix for https://github.com/FirebaseExtended/firebase-dart/issues/309

Tested by checking the chrome debug console:
![d02](https://user-images.githubusercontent.com/7897132/77865769-ab1dbb00-71f5-11ea-999d-3307a4ce39ba.png)

And the firebase analytics debug console:
![d01](https://user-images.githubusercontent.com/7897132/77865792-bec92180-71f5-11ea-92dc-8050263a93b8.png)


Environment in which it was tested:

Dart version: 2.8.0

OS: windows

Flutter doctor just in case:

```
[√] Flutter (Channel dev, v1.16.1, on Microsoft Windows [Version 10.0.18363.752], locale en-US)
    • Flutter version 1.16.1 at C:\dev\flutter
    • Framework revision e6b0f5f238 (11 days ago), 2020-03-18 21:56:02 -0400
    • Engine revision 216c420a2c
    • Dart version 2.8.0 (build 2.8.0-dev.15.0 96cf889e6b)


[√] Android toolchain - develop for Android devices (Android SDK version 29.0.2)
    • Android SDK at C:\dev\android_home
    • Android NDK location not configured (optional; useful for native profiling support)
    • Platform android-29, build-tools 29.0.2
    • ANDROID_HOME = C:\dev\android_home
    • Java binary at: C:\Program Files\Android\Android Studio\jre\bin\java
    • Java version OpenJDK Runtime Environment (build 1.8.0_212-release-1586-b04)
    • All Android licenses accepted.

[√] Chrome - develop for the web
    • Chrome at C:\Program Files (x86)\Google\Chrome\Application\chrome.exe

[√] Android Studio (version 3.6)
    • Android Studio at C:\Program Files\Android\Android Studio
    • Flutter plugin version 44.0.2
    • Dart plugin version 192.7761
    • Java version OpenJDK Runtime Environment (build 1.8.0_212-release-1586-b04)

[√] VS Code (version 1.43.2)
    • VS Code at C:\Users\josue\AppData\Local\Programs\Microsoft VS Code
    • Flutter extension version 3.8.1

[√] Connected device (2 available)
    • Chrome     • chrome     • web-javascript • Google Chrome 80.0.3987.149
    • Web Server • web-server • web-javascript • Flutter Tools

• No issues found!
```