### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'auth.dart';
 import 'database.dart';
 import 'firestore.dart';

--- a/lib/src/remote_config.dart
+++ b/lib/src/remote_config.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'interop/js_interop.dart' as js_interop;
 import 'interop/remote_config_interop.dart';
 import 'js.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core