### PR TITLE
[storage] Ensure onCompletion for UploadTasks don't return anything.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.1
+
+- ensure onCompletion functions for UploadTasks don't returning anything. [Issue](https://github.com/FirebaseExtended/firebase-dart/issues/343).
+
 ## 7.3.0
 
 - added additional options to interop 'Settings' to Fix Timestamp Error.

--- a/lib/src/storage.dart
+++ b/lib/src/storage.dart
@@ -319,9 +319,10 @@ class UploadTask extends JsObjectWrapper<storage_interop.UploadTaskJsImpl> {
       });
 
       var errorWrapper = allowInterop((e) => _changeController.addError(e));
-      // This seems to be a dart-lang/sdk error.
-      // See https://github.com/dart-lang/sdk/issues/43781
       var onCompletion = allowInterop(() {
+        // Needing a block here (instead of an inline => function) seems to be a
+        // dart-lang/sdk quirk/feature.
+        // See https://github.com/dart-lang/sdk/issues/43781
         _changeController.close();
       });
 

--- a/lib/src/storage.dart
+++ b/lib/src/storage.dart
@@ -319,6 +319,8 @@ class UploadTask extends JsObjectWrapper<storage_interop.UploadTaskJsImpl> {
       });
 
       var errorWrapper = allowInterop((e) => _changeController.addError(e));
+      // This seems to be a dart-lang/sdk error.
+      // See https://github.com/dart-lang/sdk/issues/43781
       var onCompletion = allowInterop(() {
         _changeController.close();
       });

--- a/lib/src/storage.dart
+++ b/lib/src/storage.dart
@@ -319,7 +319,9 @@ class UploadTask extends JsObjectWrapper<storage_interop.UploadTaskJsImpl> {
       });
 
       var errorWrapper = allowInterop((e) => _changeController.addError(e));
-      var onCompletion = allowInterop(() => _changeController.close());
+      var onCompletion = allowInterop(() {
+        _changeController.close();
+      });
 
       void startListen() {
         _onStateChangedUnsubscribe = jsObject.on(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase
 description: Firebase libraries for Dart on the web and server
-version: 7.3.0
+version: 7.3.1
 homepage: https://github.com/FirebaseExtended/firebase-dart
 
 environment:


### PR DESCRIPTION
This ensures the onCompletion function created to handle UploadTasks doesn't return anything.

### Testing

All tests pass, I tried to write a test for this case, but I wasn't able to pick up the exception with something like this in `storage_test.dart`:

```dart
test('does not throw in another zone', () async {
  final storage = app.storage();
  final subfolder = storage.ref(validDatePath()).child('sub');

  await runZonedGuarded(() async {
    final task = subfolder.putString('testing 1 2 3');
    task.pause();
    // The error only gets thrown when we listen to the status updates
    final subscription = task.onStateChanged.listen((event) => event);
    subscription.onDone(() {
      print('stream done!');
      subscription.cancel();
    });
    await Future.delayed(const Duration(seconds: 10));
    task.resume();
    await expectLater(task.future, completes);
  }, (e, s) {
    /* This NEVER happens */
    print(e);
  });

  await subfolder.delete();
});
```


### Related issues

Fixes https://github.com/FirebaseExtended/firebase-dart/issues/343