### PR TITLE
Change data type for the data returned from function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.2-dev
+
+- Changing the return type of cloud function call return from Map<String, dynamic> to dynamic so any value can be returned from the cloud function call
+
 ## 7.3.1
 
 - ensure onCompletion functions for UploadTasks don't returning anything. [Issue](https://github.com/FirebaseExtended/firebase-dart/issues/343).

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -74,5 +74,5 @@ class HttpsCallableResult
       functions_interop.HttpsCallableResultJsImpl jsObject)
       : super.fromJsObject(jsObject);
 
-  Map<String, dynamic> get data => dartify(jsObject.data);
+  dynamic get data => dartify(jsObject.data);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase
 description: Firebase libraries for Dart on the web and server
-version: 7.3.1
+version: 7.3.2-dev
 homepage: https://github.com/FirebaseExtended/firebase-dart
 
 environment:


### PR DESCRIPTION
Changing the data type of the cloud function return data from Map<String, dynamic> to dynamic, so that any type of data can be received as a cloud function return