### PR TITLE
Relax analytics null safe restrictions

### DIFF
--- a/firebase/CHANGELOG.md
+++ b/firebase/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 9.0.1-dev
 
+- Relax null-safe restrictions in analytics.  
+  This fixes these issues:
+  - Allow resetting the screen name by passing a null screen name.
+  - Allow resetting the user id by passing a null uid.
+  - Allow resetting a user property by passing a null value for the user property.
+
 ## 9.0.0
 
 - Enable null safety

--- a/firebase/lib/src/analytics.dart
+++ b/firebase/lib/src/analytics.dart
@@ -32,7 +32,7 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
     }
   }
 
-  void setUserId(String id, [AnalyticsCallOptions? options]) {
+  void setUserId(String? id, [AnalyticsCallOptions? options]) {
     if (options != null) {
       jsObject.setUserId(id, options.jsObject);
     } else {

--- a/firebase/lib/src/analytics.dart
+++ b/firebase/lib/src/analytics.dart
@@ -11,7 +11,7 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
   Analytics._fromJsObject(analytics_interop.AnalyticsJsImpl jsObject)
       : super.fromJsObject(jsObject);
 
-  void logEvent(String eventName, Map<dynamic, dynamic> eventParams,
+  void logEvent(String eventName, Map<String, dynamic> eventParams,
       [AnalyticsCallOptions? options]) {
     if (options != null) {
       jsObject.logEvent(eventName, jsify(eventParams), options.jsObject);

--- a/firebase/lib/src/analytics.dart
+++ b/firebase/lib/src/analytics.dart
@@ -40,7 +40,7 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
     }
   }
 
-  void setUserProperties(Map<String, String> properties,
+  void setUserProperties(Map<String, String?> properties,
       [AnalyticsCallOptions? options]) {
     if (options != null) {
       jsObject.setUserProperties(jsify(properties), options.jsObject);

--- a/firebase/lib/src/analytics.dart
+++ b/firebase/lib/src/analytics.dart
@@ -24,7 +24,7 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
     jsObject.setAnalyticsCollectionEnabled(enabled);
   }
 
-  void setCurrentScreen(String screenName, [AnalyticsCallOptions? options]) {
+  void setCurrentScreen(String? screenName, [AnalyticsCallOptions? options]) {
     if (options != null) {
       jsObject.setCurrentScreen(screenName, options.jsObject);
     } else {

--- a/firebase/lib/src/interop/analytics_interop.dart
+++ b/firebase/lib/src/interop/analytics_interop.dart
@@ -10,7 +10,7 @@ abstract class AnalyticsJsImpl {
   external void setAnalyticsCollectionEnabled(bool enabled);
   external void setCurrentScreen(String? screenName,
       [AnalyticsCallOptionsJsImpl options]);
-  external void setUserId(String id, [AnalyticsCallOptionsJsImpl options]);
+  external void setUserId(String? id, [AnalyticsCallOptionsJsImpl options]);
   external void setUserProperties(Object properties,
       [AnalyticsCallOptionsJsImpl options]);
 }

--- a/firebase/lib/src/interop/analytics_interop.dart
+++ b/firebase/lib/src/interop/analytics_interop.dart
@@ -8,7 +8,7 @@ abstract class AnalyticsJsImpl {
   external void logEvent(String eventName, Object eventParams,
       [AnalyticsCallOptionsJsImpl options]);
   external void setAnalyticsCollectionEnabled(bool enabled);
-  external void setCurrentScreen(String screenName,
+  external void setCurrentScreen(String? screenName,
       [AnalyticsCallOptionsJsImpl options]);
   external void setUserId(String id, [AnalyticsCallOptionsJsImpl options]);
   external void setUserProperties(Object properties,


### PR DESCRIPTION
This PR aims to relax null safe type restrictions to allow `null` values where other platform implementations also allow `null` values.

See this comment for more details: https://github.com/FirebaseExtended/flutterfire/pull/5341#issuecomment-802318246

tl;dr: There are some types in this package that don't allow `null` values, but on other platforms explicitly allow `null` values.
These `null` values are often important as the `null` value signals that a property should be reset.

For example, setting a `null` `screenName` or `uid` resets it in all further analytics events.
Or setting a user property to `null` removes this user property for the user.

Blocks https://github.com/FirebaseExtended/flutterfire/pull/5341

/cc @kevmoo mentioning you here as you've did the null-safe PR :) 